### PR TITLE
fix(transactions.go) - Meta field type change.

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -45,7 +45,7 @@ type Transaction struct {
 	ID              int                    `json:"id,omitempty"`
 	CreatedAt       string                 `json:"createdAt,omitempty"`
 	Domain          string                 `json:"domain,omitempty"`
-	Metadata        string                 `json:"metadata,omitempty"` //TODO: why is transaction metadata a string?
+	Metadata        map[string]interface{}                 `json:"metadata,omitempty"`
 	Status          string                 `json:"status,omitempty"`
 	Reference       string                 `json:"reference,omitempty"`
 	Amount          float32                `json:"amount,omitempty"`

--- a/transaction.go
+++ b/transaction.go
@@ -45,7 +45,7 @@ type Transaction struct {
 	ID              int                    `json:"id,omitempty"`
 	CreatedAt       string                 `json:"createdAt,omitempty"`
 	Domain          string                 `json:"domain,omitempty"`
-	Metadata        map[string]interface{}                 `json:"metadata,omitempty"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
 	Status          string                 `json:"status,omitempty"`
 	Reference       string                 `json:"reference,omitempty"`
 	Amount          float32                `json:"amount,omitempty"`


### PR DESCRIPTION
In transactions.go, the meta field on the Transactions struct was set to `string` and has been updated to `map[string]interface{}`

Data returned from the Paystack's API, that field is a JSON Object with children, so a string wouldn't suffice when unmarshaling the JSON to Transactions struct. 

This fix has been implemented and is currently in use in a production software and others.
First usage: [https://helpnow.ng](https://helpnow.ng) ( If this program is still ongoing)