### PR TITLE
Fixed conflicting module name in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elvis-chuks/paystack-go
+module github.com/rpip/paystack-go
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rpip/paystack-go
+module github.com/elvis-chuks/paystack-go
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Obayanju/paystack-go
+module github.com/rpip/paystack-go
 
 go 1.16
 


### PR DESCRIPTION
current go.mod file has the module name github.com/Obayanju/paystack-go when it should be github.com/rpip/paystack-g0 because the repo exists on rpip's githu account