### PR TITLE
changed bvn match logic to match Paystack's current bvn match endpoint

### DIFF
--- a/bank.go
+++ b/bank.go
@@ -26,13 +26,29 @@ type BankList struct {
 	Values []Bank `json:"data,omitempty"`
 }
 
-// BVNResponse represents response from resolve_bvn endpoint
+type BVNRequest struct {
+	BVN           string `json:"bvn,omitempty"`
+	AccountNumber string `json:"account_number,omitempty"`
+	BankCode      string `json:"bank_code,omitempty"`
+	FirstName     string `json:"first_name,omitempty"`
+	LastName      string `json:"last_name,omitempty"`
+	MiddleName    string `json:"middle_name,omitempty"`
+}
+
+// BVNResponse represents response from match bvn endpoint
 type BVNResponse struct {
+	Data struct {
+		BVN           string `json:"bvn,omitempty"`
+		IsBlacklisted bool   `json:"is_blacklisted,omitempty"`
+		AccountNumber bool   `json:"account_number,omitempty"`
+		FirstName     bool   `json:"first_name,omitempty"`
+		MiddleName    bool   `json:"middle_name,omitempty"`
+		LastName      bool   `json:"last_name,omitempty"`
+	}
 	Meta struct {
 		CallsThisMonth int `json:"calls_this_month,omitempty"`
 		FreeCallsLeft  int `json:"free_calls_left,omitempty"`
 	}
-	BVN string
 }
 
 // List returns a list of all the banks.
@@ -43,11 +59,10 @@ func (s *BankService) List() (*BankList, error) {
 	return banks, err
 }
 
-// ResolveBVN docs https://developers.paystack.co/v1.0/reference#resolve-bvn
-func (s *BankService) ResolveBVN(bvn int) (*BVNResponse, error) {
-	u := fmt.Sprintf("/bank/resolve_bvn/%d", bvn)
+// MatchBVN docs https://paystack.com/docs/identity-verification/verify-bvn-match/
+func (s *BankService) MatchBVN(req *BVNRequest) (*BVNResponse, error) {
 	resp := &BVNResponse{}
-	err := s.client.Call("GET", u, nil, resp)
+	err := s.client.Call("POST", "/bvn/match", req, resp)
 	return resp, err
 }
 

--- a/bank.go
+++ b/bank.go
@@ -62,7 +62,7 @@ func (s *BankService) List() (*BankList, error) {
 // MatchBVN docs https://paystack.com/docs/identity-verification/verify-bvn-match/
 func (s *BankService) MatchBVN(req *BVNRequest) (*BVNResponse, error) {
 	resp := &BVNResponse{}
-	err := s.client.Call("POST", "/bvn/match", req, resp)
+	err := s.client.Call("POST", "/bvn/match", req, &resp)
 	return resp, err
 }
 

--- a/bank_test.go
+++ b/bank_test.go
@@ -11,10 +11,18 @@ func TestBankList(t *testing.T) {
 	}
 }
 
-func TestResolveBVN(t *testing.T) {
+func TestMatchBVN(t *testing.T) {
+	req := &BVNRequest{
+		AccountNumber: "0001234560",
+		BankCode:      "058",
+		FirstName:     "Customer",
+		LastName:      "2",
+		MiddleName:    "1",
+	}
 	// Test invlaid BVN.
 	// Err not nill. Resp status code is 400
-	resp, err := c.Bank.ResolveBVN(21212917)
+	req.BVN = "21212917"
+	resp, err := c.Bank.MatchBVN(req)
 	if err == nil {
 		t.Errorf("Expected error for invalid BVN, got %+v'", resp)
 	}
@@ -22,7 +30,8 @@ func TestResolveBVN(t *testing.T) {
 	// Test free calls limit
 	// Error is nil
 	// &{Meta:{CallsThisMonth:0 FreeCallsLeft:0} BVN:cZ+MKrsLAqJCUi+hxIdQqw==}’
-	resp, err = c.Bank.ResolveBVN(21212917741)
+	req.BVN = "21212917741"
+	resp, err = c.Bank.MatchBVN(req)
 	if resp.Meta.FreeCallsLeft != 0 {
 		t.Errorf("Expected free calls limit exceeded, got %+v'", resp)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rpip/paystack-go
+module github.com/sayopaul/paystack-go
 
 go 1.16
 


### PR DESCRIPTION
The previously implemented ResolveBVN() method was returning the message `message:BVN Service Unavailable status:false` due to Paystack changing their BVN functionality and endpoint totally. This pull request updates the library to use Paystack's recent BVN match endpoint as seen here [https://paystack.com/docs/identity-verification/verify-bvn-match/](https://paystack.com/docs/identity-verification/verify-bvn-match/). I also updated the tests. 