### PR TITLE
Resolves: mis-spelled 'paid_at` json tag in transaction.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ paystack-go is a Go client library for accessing the Paystack API.
 
 Where possible, the services available on the client groups the API into logical chunks and correspond to the structure of the Paystack API documentation at https://developers.paystack.co/v1.0/reference.
 
-#Note: This Project was forked off https://github.com/rpip/paystack-go with the intention to continue active development ad maintaince 
-
 ## Usage
 
 ``` go

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ paystack-go is a Go client library for accessing the Paystack API.
 
 Where possible, the services available on the client groups the API into logical chunks and correspond to the structure of the Paystack API documentation at https://developers.paystack.co/v1.0/reference.
 
+#Note: This Project was forked off https://github.com/rpip/paystack-go with the intention to continue active development ad maintaince 
+
 ## Usage
 
 ``` go

--- a/transaction.go
+++ b/transaction.go
@@ -51,7 +51,7 @@ type Transaction struct {
 	Amount          float32                `json:"amount,omitempty"`
 	Message         string                 `json:"message,omitempty"`
 	GatewayResponse string                 `json:"gateway_response,omitempty"`
-	PaidAt          string                 `json:"piad_at,omitempty"`
+	PaidAt          string                 `json:"paid_at,omitempty"`
 	Channel         string                 `json:"channel,omitempty"`
 	Currency        string                 `json:"currency,omitempty"`
 	IPAddress       string                 `json:"ip_address,omitempty"`


### PR DESCRIPTION
Fixes #17 mis-spelled 'paidt_at` json tag in transaction.go
