### PR TITLE
Fix transaction metadata type

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -45,7 +45,7 @@ type Transaction struct {
 	ID              int                    `json:"id,omitempty"`
 	CreatedAt       string                 `json:"createdAt,omitempty"`
 	Domain          string                 `json:"domain,omitempty"`
-	Metadata        string                 `json:"metadata,omitempty"` //TODO: why is transaction metadata a string?
+	Metadata        Metadata               `json:"metadata,omitempty"` //TODO: why is transaction metadata a string?
 	Status          string                 `json:"status,omitempty"`
 	Reference       string                 `json:"reference,omitempty"`
 	Amount          float32                `json:"amount,omitempty"`

--- a/transaction.go
+++ b/transaction.go
@@ -45,7 +45,7 @@ type Transaction struct {
 	ID              int                    `json:"id,omitempty"`
 	CreatedAt       string                 `json:"createdAt,omitempty"`
 	Domain          string                 `json:"domain,omitempty"`
-	Metadata        Metadata               `json:"metadata,omitempty"` //TODO: why is transaction metadata a string?
+	Metadata        Metadata               `json:"metadata,omitempty"`
 	Status          string                 `json:"status,omitempty"`
 	Reference       string                 `json:"reference,omitempty"`
 	Amount          float32                `json:"amount,omitempty"`


### PR DESCRIPTION
PR updates transaction metadata type to Metadata

Root Cause
--------------

Error when transaction.Verify(...) method is called

`1 error(s) decoding: * 'metadata' expected type 'string', got unconvertible type 'map[string]interface {}`